### PR TITLE
Editorial: add note about casting to f16

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -42,6 +42,11 @@ contributors: Kevin Gibbons
       1. Let _n64_ be the result of converting _n16_ to IEEE 754-2019 binary64 format.
       1. Return the ECMAScript Number value corresponding to _n64_.
     </emu-alg>
+
+    <emu-note>
+      <p>This operation is not the same as casting to binary32 and then to binary16 because of the possibility of double-rounding: consider the number _k_ = *1.00048828125000022204*<sub>𝔽</sub>, for example, for which which Math.f16round(_k_) is *1.0009765625*<sub>𝔽</sub>, but Math.f16round(Math.fround(_k_)) is *1*<sub>𝔽</sub>.</p>
+      <p>Not all platforms provide native support for casting from binary64 to binary16. There are various libraries which can provide this, including the MIT-licensed <a href="https://half.sourceforge.net/">half</a> library. Alternatively, it is possible to first cast from binary64 to binary32 under roundTiesToEven and then check whether the result could lead to incorrect double-rounding. The cases which could can be handled explicitly by adjusting the mantissa of the binary32 value so that it is the value which would be produced by performing the initial cast under roundTiesToOdd. Casting the adjusted value to binary16 under roundTiesToEven then produces the correct value.</p>
+    </emu-note>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
Fixes #13 (I think); cc @phoddie.

I'd welcome improvements to the wording here. Alternatively I could just link to [Firefox's thoroughly commented implementation](https://searchfox.org/mozilla-central/rev/dfaf02d68a7cb018b6cad7e189f450352e2cde04/js/src/jit/MacroAssembler.cpp#7931-8177).